### PR TITLE
New API with fewer allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsrc"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Kyle Sabo"]
 description = "Find a resource from a PE image without loading it."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "Find a resource from a PE image without loading it."
 [dependencies]
 goblin = {version="0.5", features=["pe32", "pe64"]}
 scroll = { version = "0.11", features = ["derive"] }
-clap = "2"
 anyhow = "1"
 thiserror = "1"
 widestring = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ scroll = { version = "0.11", features = ["derive"] }
 anyhow = "1"
 thiserror = "1"
 widestring = "0.5"
+memmap2 = "0.5"
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ description = "Find a resource from a PE image without loading it."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Uses allocations to cache the parsed resource directory, for faster repeated searches.
+alloc = []
+
 [dependencies]
 goblin = {version="0.5", features=["pe32", "pe64"]}
 scroll = { version = "0.11", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ goblin = {version="0.5", default-features = false, features=["pe32", "pe64"]}
 scroll = { version = "0.11", default-features = false, features = ["derive"] }
 anyhow = { version="1", default-features = false }
 thiserror = "1"
-widestring = { version="0.5", default-features = false }
 memmap2 = "0.5"
 either = { version="1.8", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "Find a resource from a PE image without loading it."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# Uses allocations to cache the parsed resource directory, for (potentially) faster repeated searches.
 # Note that not enabling this feature does not make the package no_std or not use allocations at all;
 # several of the dependencies (i.e. goblin) will always need to allocate memory.
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { version="1", default-features = false }
 thiserror = "1"
 widestring = { version="0.5", default-features = false }
 memmap2 = "0.5"
+either = { version="1.8", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,17 @@ description = "Find a resource from a PE image without loading it."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# Uses allocations to cache the parsed resource directory, for faster repeated searches.
+# Uses allocations to cache the parsed resource directory, for (potentially) faster repeated searches.
+# Note that not enabling this feature does not make the package no_std or not use allocations at all;
+# several of the dependencies (i.e. goblin) will always need to allocate memory.
 alloc = []
 
 [dependencies]
-goblin = {version="0.5", features=["pe32", "pe64"]}
-scroll = { version = "0.11", features = ["derive"] }
-anyhow = "1"
+goblin = {version="0.5", default-features = false, features=["pe32", "pe64"]}
+scroll = { version = "0.11", default-features = false, features = ["derive"] }
+anyhow = { version="1", default-features = false }
 thiserror = "1"
-widestring = "0.5"
+widestring = { version="0.5", default-features = false }
 memmap2 = "0.5"
 
 [profile.release]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,9 @@
 use ::rsrc::*;
 
 fn main() -> Result<(), pe_resource::PEError> {
-    let filename = std::env::args().nth(1).expect("missing argument 1: path to input PE file");
+    let filename = std::env::args()
+        .nth(1)
+        .expect("missing argument 1: path to input PE file");
 
     let resources = pe_resource::find_resource_directory_from_pe(&filename)?;
 
@@ -12,6 +14,12 @@ fn main() -> Result<(), pe_resource::PEError> {
         "pmres header: {:?}",
         std::str::from_utf8(&pmres_data2.buf[0..4]).unwrap_or("ERROR")
     );
+
+    println!("Resource tree:\n{:?}", resources);
+
+    for resource in resources.iter() {
+        println!("Enumerated resource: {}/{}/{}", resources.to_string(resource.name), resources.to_string(resource.id), resources.to_string(resource.data.id));
+    }
 
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,7 +18,13 @@ fn main() -> Result<(), pe_resource::PEError> {
     println!("Resource tree:\n{:?}", resources);
 
     for resource in resources.iter() {
-        println!("Enumerated resource: {}/{}/{}", resources.to_string(resource.name), resources.to_string(resource.id), resources.to_string(resource.data.id));
+        //println!("Enumerated resource: {}/{}/{}", resources.to_string(resource.name), resources.to_string(resource.id), resources.to_string(resource.data.id));
+        println!(
+            "Enumerated resource: {}/{}/{}",
+            String::from_iter(resources.to_chars(resource.name)),
+            String::from_iter(resources.to_chars(resource.id)),
+            String::from_iter(resources.to_chars(resource.data.id))
+        );
     }
 
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,25 +1,9 @@
 use ::rsrc::*;
 
 fn main() -> Result<(), rsrc::PEError> {
-    let matches = clap::App::new("rsrc")
-        .arg(
-            clap::Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .multiple(true)
-                .help("log verbose messages"),
-        )
-        .arg(
-            clap::Arg::with_name("input")
-                .required(true)
-                .index(1)
-                .help("path to input PE file"),
-        )
-        .get_matches();
+    let filename = std::env::args().nth(1).expect("missing argument 1: path to input PE file");
 
-    let filename = matches.value_of("input").unwrap();
-
-    let resources = rsrc::find_resource_directory_from_pe(filename)?;
+    let resources = rsrc::find_resource_directory_from_pe(&filename)?;
 
     let pmres_data2 = resources.find(&"WEVT_TEMPLATE", &"#1")?;
     // let pmres_resource_data = pmres_data2.ok_or(rsrc::PEError::NoResourceTable())?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,9 +1,9 @@
 use ::rsrc::*;
 
-fn main() -> Result<(), rsrc::PEError> {
+fn main() -> Result<(), pe_resource::PEError> {
     let filename = std::env::args().nth(1).expect("missing argument 1: path to input PE file");
 
-    let resources = rsrc::find_resource_directory_from_pe(&filename)?;
+    let resources = pe_resource::find_resource_directory_from_pe(&filename)?;
 
     let pmres_data2 = resources.find(&"WEVT_TEMPLATE", &"#1")?;
     // let pmres_resource_data = pmres_data2.ok_or(rsrc::PEError::NoResourceTable())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 mod rsrc {
     use core::mem::size_of;
+    use scroll::Pread;
     use thiserror::Error;
     use widestring::{U16Str, U16String};
-    use scroll::Pread;
 
     #[derive(Error, Debug)]
     pub enum PEError {
@@ -22,60 +22,60 @@ mod rsrc {
         ResourceNameNotFound(),
 
         #[error("An error was returned when prasing the PE: {0}")]
-        GoblinError(goblin::error::Error)
+        GoblinError(goblin::error::Error),
     }
 
     // struct _IMAGE_RESOURCE_DIRECTORY, winnt.h
     #[repr(C)]
-    struct _ImageResourceDirectory {
+    pub struct _ImageResourceDirectory {
         characteristics: u32,         // offset 0
         time_date_stamp: u32,         // offset 4
         major_version: u16,           // offset 8
         minor_version: u16,           // offset 10
         number_of_named_entries: u16, // offset 12
         number_of_id_entries: u16,    // offset 14
-        // IMAGE_RESOURCE_DIRECTORY_ENTRY DirectoryEntries[]; // offset 16
+                                      // IMAGE_RESOURCE_DIRECTORY_ENTRY DirectoryEntries[]; // offset 16
     }
 
     #[repr(C)]
     #[derive(Pread)]
-    struct _NamedResourceEntry {
-        name: u32, // high-bit: 1, bits 0-31: offset
+    pub struct _NamedResourceEntry {
+        pub name: u32, // high-bit: 1, bits 0-31: offset
     }
 
     #[repr(C)]
-    struct _IdResourceEntry {
+    pub struct _IdResourceEntry {
         unused: u16,
-        id: u16,
+        pub id: u16,
     }
 
     #[repr(C)]
     #[derive(Pread)]
-    struct _DataDirectoryEntry {
-        offset: u32, // high-bit: 0, bits 0-31: offset
+    pub struct _DataDirectoryEntry {
+        pub offset: u32, // high-bit: 0, bits 0-31: offset
     }
 
     #[repr(C)]
-    struct _SubDirectoryEntry {
-        offset: u32, // high-bit: 1, bits 0-31: offset to another _ImageResourceDirectoryEntry
+    pub struct _SubDirectoryEntry {
+        pub offset: u32, // high-bit: 1, bits 0-31: offset to another _ImageResourceDirectoryEntry
     }
 
     // struct _IMAGE_RESOURCE_DIRECTORY_ENTRY, winnt.h
     #[repr(C)]
     #[derive(Pread)]
-    struct _ImageResourceDirectoryEntry {
-        u1: _NamedResourceEntry, // union _NamedResourceEntry / _IdResourceEntry
-        u2: _DataDirectoryEntry, // union _DataDirectoryEntry / _SubDirectoryEntry
+    pub struct _ImageResourceDirectoryEntry {
+        pub u1: _NamedResourceEntry, // union _NamedResourceEntry / _IdResourceEntry
+        pub u2: _DataDirectoryEntry, // union _DataDirectoryEntry / _SubDirectoryEntry
     }
 
     // struct _IMAGE_RESOURCE_DATA_ENTRY, winnt.h
     #[repr(C)]
     #[derive(Pread)]
-    struct _ImageResourceDataEntry {
-        offset_to_data: u32, // offset 0
-        size: u32,           // offset 4
-        code_page: u32,      // offset 8
-        _reserved: u32,      // offset 12
+    pub struct _ImageResourceDataEntry {
+        pub offset_to_data: u32, // offset 0
+        pub size: u32,           // offset 4
+        pub code_page: u32,      // offset 8
+        _reserved: u32,          // offset 12
     }
 
     #[derive(Debug, Clone)]
@@ -86,15 +86,42 @@ mod rsrc {
         pub data_size: usize,
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Copy, Clone)]
     pub struct IndexedString {
-        offset: usize,
-        cch: usize
+        pub offset: usize,
+        pub cch: usize,
+    }
+
+    impl IndexedString {
+        pub fn new(buf: &[u8], offset: usize) -> IndexedString {
+            let cch = buf.pread_with::<u16>(offset, scroll::LE).unwrap() as usize;
+            if (cch * 2) + offset + 2 > buf.len() {
+                panic!("oh noes");
+            }
+            IndexedString {
+                offset: offset + 2,
+                cch,
+            }
+        }
+
+        pub fn fmt_with_buffer(&self, buf: &[u8], f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            unsafe {
+                write!(f, "{}", self.to_string_with_buffer(buf))
+            }
+        }
+
+        pub fn to_string_with_buffer(&self, buf: &[u8]) -> String {
+            unsafe {
+                let p = &buf[self.offset] as *const u8 as *const u16;
+                let name_str: &U16Str = U16Str::from_ptr(p, self.cch);
+                name_str.to_string().unwrap()
+            }
+        }
     }
 
     // impl std::fmt::Display for IndexedString {
     //     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    //         let 
+    //         let
     //     }
     // }
 
@@ -102,7 +129,7 @@ mod rsrc {
         fn eq_with_buffer(&self, buf: &[u8], other: &Rhs) -> bool;
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Copy, Clone)]
     pub enum ResourceIdType {
         Name(IndexedString),
         Id(u16),
@@ -114,18 +141,18 @@ mod rsrc {
         if !name.is_empty() {
             let mut chars_lossy = name.as_slice().iter();
             if let Some(c) = chars_lossy.next() {
-                if *c == 35 { // 35 == '#'
+                if *c == 35 {
+                    // 35 == '#'
                     let mut parsed_id: u16 = 0;
                     let mut has_value = false;
                     for x in chars_lossy {
-                        if *x >= 48 && *x <= 57 { // '0' through '9'
+                        if *x >= 48 && *x <= 57 {
+                            // '0' through '9'
                             parsed_id = parsed_id * 10 + (*x - 48); // TODO: Check for u16 overflow
                             has_value = true;
-                        }
-                        else if *x == 0 {
+                        } else if *x == 0 {
                             break;
-                        }
-                        else {
+                        } else {
                             return false;
                         }
                     }
@@ -151,15 +178,23 @@ mod rsrc {
     }
 
     impl ResourceIdPartialEq<u16> for ResourceIdType {
-        fn eq_with_buffer(&self, buf: &[u8], id: &u16) -> bool
-        {
+        fn eq_with_buffer(&self, buf: &[u8], id: &u16) -> bool {
             match self {
                 ResourceIdType::Id(x) => *x == *id,
                 ResourceIdType::Name(name) => unsafe {
                     let p = &buf[name.offset] as *const u8 as *const u16;
                     let name_str: &U16Str = U16Str::from_ptr(p, name.cch);
                     compare_str_id(name_str, *id)
-                }
+                },
+            }
+        }
+    }
+
+    impl ResourceIdType {
+        pub fn to_string_with_buffer(&self, buf: &[u8]) -> String {
+            match self {
+                ResourceIdType::Id(x) => x.to_string(),
+                ResourceIdType::Name(name) => name.to_string_with_buffer(buf)
             }
         }
     }
@@ -184,14 +219,6 @@ mod rsrc {
         //     U16Str::from_ptr(str, cch)
         // }
 
-        fn get_indexed_str(buf: &[u8], offset: usize) -> IndexedString {
-            let cch = buf.pread_with::<u16>(offset, scroll::LE).unwrap() as usize;
-            if (cch * 2) + offset + 2 > buf.len() {
-                panic!("oh noes");
-            }
-            IndexedString { offset: offset + 2, cch}
-        }
-
         pub fn parse(
             buf: &[u8],
             directory_offset: usize,
@@ -208,13 +235,14 @@ mod rsrc {
             for i in 0..num_named_entries + num_id_entries {
                 let cur_offset = offset + size_of::<_ImageResourceDirectoryEntry>() * i as usize;
 
-                let entry: _ImageResourceDirectoryEntry = buf.pread_with(cur_offset, scroll::LE).unwrap();
+                let entry: _ImageResourceDirectoryEntry =
+                    buf.pread_with(cur_offset, scroll::LE).unwrap();
 
                 let id = if entry.u1.name & 0x8000_0000 != 0 {
                     // entry is a _NamedResourceEntry
 
                     let name_offset = entry.u1.name & 0x7FFF_FFFF;
-                    let name = Self::get_indexed_str(buf, name_offset as usize);
+                    let name = IndexedString::new(buf, name_offset as usize);
                     ResourceIdType::Name(name)
                 } else {
                     // entry is a _IdResourceEntry
@@ -225,7 +253,8 @@ mod rsrc {
                     // entry is not a subdirectory
                     let offset_to_data_entry = entry.u2.offset as usize;
 
-                    let entry_data: _ImageResourceDataEntry = buf.pread_with(offset_to_data_entry, scroll::LE).unwrap();
+                    let entry_data: _ImageResourceDataEntry =
+                        buf.pread_with(offset_to_data_entry, scroll::LE).unwrap();
 
                     entries.push(ImageResourceEntry::Data(ImageResourceDirectoryEntry {
                         id: id,
@@ -249,7 +278,12 @@ mod rsrc {
         }
 
         // Win32 FindResourceW
-        pub fn find<T, U>(&self, name: &T, id: &U, buf: &[u8]) -> Option<ImageResourceDirectoryEntry>
+        pub fn find<T, U>(
+            &self,
+            name: &T,
+            id: &U,
+            buf: &[u8],
+        ) -> Option<ImageResourceDirectoryEntry>
         where
             ResourceIdType: ResourceIdPartialEq<T>,
             ResourceIdType: ResourceIdPartialEq<U>,
@@ -293,52 +327,248 @@ pub mod pe_resource {
     pub use crate::rsrc::PEError;
     pub use crate::rsrc::ResourceIdPartialEq;
     use crate::rsrc::*;
+    use core::mem::size_of;
+    use scroll::Pread;
+    use std::iter::FusedIterator;
 
     #[derive(Debug)]
-    pub struct ImageResource {
+    pub struct ImageResource<'a> {
         resource: ImageResourceEntry,
         resource_section_table: goblin::pe::section_table::SectionTable,
         pub image_file: memmap2::Mmap,
         resource_table_offset: usize,
-        resource_table_end: usize
+        resource_table_end: usize,
+        _phantom: std::marker::PhantomData<&'a u8>,
     }
 
     #[derive(Debug)]
     pub struct ResourceData<'a> {
         pub id: ResourceIdType, // The resource compiler likes to put the LANGUAGE value as the ID, not the code page
-        pub code_page: u32, // Usually zero?
+        pub code_page: u32,     // Usually zero?
         pub buf: &'a [u8],
     }
 
-    impl ImageResource {
+    #[derive(Debug)]
+    pub struct Resource<'a> {
+        pub name: ResourceIdType,
+        pub id: ResourceIdType,
+        pub data: ResourceData<'a>,
+    }
+
+    impl<'a> ImageResource<'a> {
         // Win32 FindResourceW
         // Wrapper around ImageResourceEntry::find that returns only the buffer slice for the found resource
         pub fn find<T, U>(&self, name: &T, id: &U) -> Result<ResourceData, PEError>
         where
             ResourceIdType: ResourceIdPartialEq<T>,
-            ResourceIdType: ResourceIdPartialEq<U>
+            ResourceIdType: ResourceIdPartialEq<U>,
         {
-            match self.resource.find(name, id, &self.image_file[self.resource_table_offset..self.resource_table_end]) {
+            match self.resource.find(
+                name,
+                id,
+                &self.image_file[self.resource_table_offset..self.resource_table_end],
+            ) {
                 Some(dir) => {
                     // Since the RVA is relative to the loaded image layout rather than the raw image on disk,
                     // we need to adjust the RVA by the difference between those two layouts.
                     let rva_to_va_offset = (self.resource_section_table.virtual_address
                         - self.resource_section_table.pointer_to_raw_data)
                         as usize;
-                    
+
                     let data = &self.image_file[dir.rva_to_data - rva_to_va_offset
                         ..dir.rva_to_data - rva_to_va_offset + dir.data_size];
 
-                    Ok(ResourceData { id: dir.id, code_page: dir.code_page, buf: data })
+                    Ok(ResourceData {
+                        id: dir.id,
+                        code_page: dir.code_page,
+                        buf: data,
+                    })
                 }
                 None => Err(PEError::ResourceNameNotFound()),
+            }
+        }
+
+        pub fn iter(&'a self) -> ImageResourceEnumerator<'a> {
+            self.into_iter()
+        }
+
+        pub fn to_string(&self, resource_id: ResourceIdType) -> String {
+            let buf = &self.image_file[self.resource_table_offset..self.resource_table_end];
+            resource_id.to_string_with_buffer(buf)
+        }
+    }
+
+    impl<'a> IntoIterator for &'a ImageResource<'a> {
+        type Item = <ImageResourceEnumerator<'a> as Iterator>::Item;
+        type IntoIter = ImageResourceEnumerator<'a>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            ImageResourceEnumerator::new(self)
+        }
+    }
+
+    struct CurrentDirectoryState {
+        id: ResourceIdType,
+        directory_offset: usize,
+        current_child_index: u16,
+        num_children: u16,
+    }
+
+    pub struct ImageResourceEnumerator<'a> {
+        image_resource: &'a ImageResource<'a>,
+        current_index: usize,                // Current index into cur_dir
+        cur_dir: [CurrentDirectoryState; 3], // Arbitrary depth limit of 3 nested directories
+    }
+
+    impl<'a> ImageResourceEnumerator<'a> {
+        pub fn new(image_resource: &'a ImageResource) -> ImageResourceEnumerator<'a> {
+            let buf: &[u8] = &image_resource.image_file
+                [image_resource.resource_table_offset..image_resource.resource_table_end];
+            let num_named_entries: u16 = buf.pread_with(12, scroll::LE).unwrap();
+            let num_id_entries: u16 = buf.pread_with(14, scroll::LE).unwrap();
+
+            ImageResourceEnumerator {
+                image_resource,
+                current_index: 0,
+                cur_dir: [
+                    CurrentDirectoryState {
+                        id: ResourceIdType::Id(0),
+                        directory_offset: 0,
+                        current_child_index: 0,
+                        num_children: num_named_entries + num_id_entries,
+                    },
+                    CurrentDirectoryState {
+                        id: ResourceIdType::Id(0),
+                        directory_offset: 0,
+                        current_child_index: 0,
+                        num_children: 0,
+                    },
+                    CurrentDirectoryState {
+                        id: ResourceIdType::Id(0),
+                        directory_offset: 0,
+                        current_child_index: 0,
+                        num_children: 0,
+                    },
+                ],
+            }
+        }
+    }
+
+    impl<'a> FusedIterator for ImageResourceEnumerator<'a> {}
+
+    impl<'a> Iterator for ImageResourceEnumerator<'a> {
+        type Item = Resource<'a>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            loop {
+                if self.cur_dir[self.current_index].current_child_index
+                    >= self.cur_dir[self.current_index].num_children
+                {
+                    // If the last item was the last in this directory, so return to the parent directory
+                    if self.current_index > 0 {
+                        self.current_index -= 1;
+                    } else {
+                        return None;
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            let buf: &[u8] = &self.image_resource.image_file
+                [self.image_resource.resource_table_offset..self.image_resource.resource_table_end];
+            let directory_offset = self.cur_dir[self.current_index].directory_offset;
+            let i = self.cur_dir[self.current_index].current_child_index;
+
+            self.cur_dir[self.current_index].current_child_index += 1;
+
+            let offset = directory_offset + size_of::<_ImageResourceDirectory>() as usize;
+
+            let cur_offset = offset + size_of::<_ImageResourceDirectoryEntry>() * i as usize;
+
+            let entry: _ImageResourceDirectoryEntry =
+                buf.pread_with(cur_offset, scroll::LE).unwrap();
+
+            let id = if entry.u1.name & 0x8000_0000 != 0 {
+                // entry is a _NamedResourceEntry
+
+                let name_offset = entry.u1.name & 0x7FFF_FFFF;
+                let name = IndexedString::new(buf, name_offset as usize);
+                ResourceIdType::Name(name)
+            } else {
+                // entry is a _IdResourceEntry
+                ResourceIdType::Id(entry.u1.name as u16)
+            };
+
+            if entry.u2.offset & 0x8000_0000 == 0 {
+                // entry is not a subdirectory
+                let offset_to_data_entry = entry.u2.offset as usize;
+
+                let entry_data: _ImageResourceDataEntry =
+                    buf.pread_with(offset_to_data_entry, scroll::LE).unwrap();
+
+                // Since the RVA is relative to the loaded image layout rather than the raw image on disk,
+                // we need to adjust the RVA by the difference between those two layouts.
+                let rva_to_va_offset = (self.image_resource.resource_section_table.virtual_address
+                    - self
+                        .image_resource
+                        .resource_section_table
+                        .pointer_to_raw_data) as usize;
+
+                let rva_to_data = entry_data.offset_to_data as usize;
+                let data_size = entry_data.size as usize;
+
+                let data = &self.image_resource.image_file
+                    [rva_to_data - rva_to_va_offset..rva_to_data - rva_to_va_offset + data_size];
+
+                let mut rsrc_name = ResourceIdType::Id(0);
+                let mut rsrc_id = ResourceIdType::Id(0);
+                if self.current_index == 2 {
+                    rsrc_name = self.cur_dir[1].id;
+                    rsrc_id = self.cur_dir[2].id;
+                }
+
+                Some(Resource {
+                    name: rsrc_name,
+                    id: rsrc_id,
+                    data: ResourceData {
+                        id,
+                        code_page: entry_data.code_page,
+                        buf: data,
+                    },
+                })
+            } else {
+                if self.current_index >= self.cur_dir.len() {
+                    panic!("Resource directory nesting is too deep");
+                }
+
+                let offset_to_subdirectory_entry = (entry.u2.offset & 0x7FFF_FFFF) as usize;
+                let num_named_entries: u16 = buf
+                    .pread_with(offset_to_subdirectory_entry + 12, scroll::LE)
+                    .unwrap();
+                let num_id_entries: u16 = buf
+                    .pread_with(offset_to_subdirectory_entry + 14, scroll::LE)
+                    .unwrap();
+
+                self.current_index += 1;
+                self.cur_dir[self.current_index] = CurrentDirectoryState {
+                    id,
+                    directory_offset: offset_to_subdirectory_entry,
+                    current_child_index: 0,
+                    num_children: num_named_entries + num_id_entries,
+                };
+
+                self.next()
             }
         }
     }
 
     pub fn find_resource_directory_from_pe(filename: &str) -> Result<ImageResource, PEError> {
-        let file = std::fs::File::open(filename).map_err(|e| PEError::BadResourceString(e.to_string()))?;
-        let mapped = unsafe { memmap2::Mmap::map(&file).map_err(|e| PEError::BadResourceString(e.to_string()))? };
+        let file =
+            std::fs::File::open(filename).map_err(|e| PEError::BadResourceString(e.to_string()))?;
+        let mapped = unsafe {
+            memmap2::Mmap::map(&file).map_err(|e| PEError::BadResourceString(e.to_string()))?
+        };
         let buf: &[u8] = &mapped;
         if buf.len() < 0x10 {
             panic!("file too small: {}", filename);
@@ -356,20 +586,19 @@ pub mod pe_resource {
                 Ok(pe)
             }
             goblin::Object::Elf(_) => Err(PEError::FormatNotSupported("elf")),
-            goblin::Object::Archive(_) => {
-                Err(PEError::FormatNotSupported("archive"))
-            }
+            goblin::Object::Archive(_) => Err(PEError::FormatNotSupported("archive")),
             goblin::Object::Mach(_) => Err(PEError::FormatNotSupported("macho")),
-            goblin::Object::Unknown(_) => {
-                Err(PEError::FormatNotSupported("unknown"))
-            }
+            goblin::Object::Unknown(_) => Err(PEError::FormatNotSupported("unknown")),
         };
 
         let pe = _pe?;
 
         let optional_header = pe.header.optional_header.unwrap();
 
-        let resource_table = optional_header.data_directories.get_resource_table().ok_or(PEError::NoResourceTable())?;
+        let resource_table = optional_header
+            .data_directories
+            .get_resource_table()
+            .ok_or(PEError::NoResourceTable())?;
 
         let resource_table_start = resource_table.virtual_address as usize;
         let resource_table_end = resource_table_start + resource_table.size as usize;
@@ -405,7 +634,7 @@ pub mod pe_resource {
         let resource = ImageResourceEntry::parse(
             &buf[offset..end],
             0,
-            ResourceIdType::Id(0)// ResourceIdType::Name(section_name.to_string()),
+            ResourceIdType::Id(0), // ResourceIdType::Name(section_name.to_string()),
         );
 
         Ok(ImageResource {
@@ -413,7 +642,8 @@ pub mod pe_resource {
             resource_section_table,
             image_file: mapped,
             resource_table_offset: offset,
-            resource_table_end: end
+            resource_table_end: end,
+            _phantom: std::marker::PhantomData {},
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,6 @@ pub mod pe_resource {
                         let thous = (val % 10) as u32;
                         val /= 10;
                         let ten_thous = (val % 10) as u32;
-                        val /= 10;
                         Some(IdIter {
                             chars: [
                                 char::from_u32_unchecked('0' as u32 + ten_thous),
@@ -522,10 +521,7 @@ pub mod pe_resource {
             match &mut self.0 {
                 Some(iter) => match iter.next() {
                     Some(x) => Some(x),
-                    None => match &mut self.1 {
-                        Some(iter2) => iter2.next(),
-                        None => None,
-                    },
+                    None => None
                 },
                 None => match &mut self.1 {
                     Some(iter2) => match iter2.next() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ mod functional {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn wevtapi() -> anyhow::Result<()> {
+    fn wevtapi() -> Result<(), rsrc::pe_resource::PEError> {
         let resource = rsrc::pe_resource::find_resource_directory_from_pe(
             "C:\\windows\\system32\\wevtapi.dll",
         )?;
@@ -21,7 +21,7 @@ mod functional {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn wevtsvc() -> anyhow::Result<()> {
+    fn wevtsvc() -> Result<(), rsrc::pe_resource::PEError> {
         let resource = rsrc::pe_resource::find_resource_directory_from_pe(
             "C:\\windows\\system32\\wevtsvc.dll",
         )?;
@@ -38,13 +38,18 @@ mod functional {
 
     #[test]
     #[cfg(target_os = "windows")]
-    fn wevtapi_enum() -> anyhow::Result<()> {
+    fn wevtapi_enum() -> Result<(), rsrc::pe_resource::PEError> {
         let resources = rsrc::pe_resource::find_resource_directory_from_pe(
             "C:\\windows\\system32\\wevtapi.dll",
         )?;
 
         for resource in &resources {
-            println!("Resource: {:?}", resource.id);
+            println!(
+                "Enumerated resource: {}/{}/{}",
+                String::from_iter(resources.to_chars(resource.name)),
+                String::from_iter(resources.to_chars(resource.id)),
+                String::from_iter(resources.to_chars(resource.data.id))
+            );
         }
 
         Ok(())

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,15 +1,17 @@
 #[cfg(test)]
 mod functional {
+    use rsrc::pe_resource::ResourceIdPartialEq;
+
     #[test]
     #[cfg(target_os = "windows")]
     fn wevtapi() -> anyhow::Result<()> {
         let resource =
-            rsrc::rsrc::find_resource_directory_from_pe("C:\\windows\\system32\\wevtapi.dll")?;
+            rsrc::pe_resource::find_resource_directory_from_pe("C:\\windows\\system32\\wevtapi.dll")?;
 
         let pmres_data = resource.find(&"WEVT_TEMPLATE", &"#1")?;
 
         assert_eq!(std::str::from_utf8(&pmres_data.buf[0..4]).unwrap(), "CRIM");
-        assert_eq!(pmres_data.id, 0x409);
+        assert!(pmres_data.id.eq_with_buffer(&resource.image_file, &0x409u16));
 
         Ok(())
     }
@@ -18,12 +20,12 @@ mod functional {
     #[cfg(target_os = "windows")]
     fn wevtsvc() -> anyhow::Result<()> {
         let resource =
-            rsrc::rsrc::find_resource_directory_from_pe("C:\\windows\\system32\\wevtsvc.dll")?;
+            rsrc::pe_resource::find_resource_directory_from_pe("C:\\windows\\system32\\wevtsvc.dll")?;
 
         let pmres_data = resource.find(&"WEVT_TEMPLATE", &"#1")?;
 
         assert_eq!(std::str::from_utf8(&pmres_data.buf[0..4]).unwrap(), "CRIM");
-        assert_eq!(pmres_data.id, 0x409);
+        assert!(pmres_data.id.eq_with_buffer(&resource.image_file, &0x409u16));
 
         Ok(())
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,13 +5,16 @@ mod functional {
     #[test]
     #[cfg(target_os = "windows")]
     fn wevtapi() -> anyhow::Result<()> {
-        let resource =
-            rsrc::pe_resource::find_resource_directory_from_pe("C:\\windows\\system32\\wevtapi.dll")?;
+        let resource = rsrc::pe_resource::find_resource_directory_from_pe(
+            "C:\\windows\\system32\\wevtapi.dll",
+        )?;
 
         let pmres_data = resource.find(&"WEVT_TEMPLATE", &"#1")?;
 
         assert_eq!(std::str::from_utf8(&pmres_data.buf[0..4]).unwrap(), "CRIM");
-        assert!(pmres_data.id.eq_with_buffer(&resource.image_file, &0x409u16));
+        assert!(pmres_data
+            .id
+            .eq_with_buffer(&resource.image_file, &0x409u16));
 
         Ok(())
     }
@@ -19,13 +22,30 @@ mod functional {
     #[test]
     #[cfg(target_os = "windows")]
     fn wevtsvc() -> anyhow::Result<()> {
-        let resource =
-            rsrc::pe_resource::find_resource_directory_from_pe("C:\\windows\\system32\\wevtsvc.dll")?;
+        let resource = rsrc::pe_resource::find_resource_directory_from_pe(
+            "C:\\windows\\system32\\wevtsvc.dll",
+        )?;
 
         let pmres_data = resource.find(&"WEVT_TEMPLATE", &"#1")?;
 
         assert_eq!(std::str::from_utf8(&pmres_data.buf[0..4]).unwrap(), "CRIM");
-        assert!(pmres_data.id.eq_with_buffer(&resource.image_file, &0x409u16));
+        assert!(pmres_data
+            .id
+            .eq_with_buffer(&resource.image_file, &0x409u16));
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn wevtapi_enum() -> anyhow::Result<()> {
+        let resources = rsrc::pe_resource::find_resource_directory_from_pe(
+            "C:\\windows\\system32\\wevtapi.dll",
+        )?;
+
+        for resource in &resources {
+            println!("Resource: {:?}", resource.id);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
All allocations done by the crate itself are now behind the `alloc` feature.
Crate dependencies (aka goblin) still perform allocations when parsing PE files.